### PR TITLE
Adjust img max width

### DIFF
--- a/dist/nodes/Image.js
+++ b/dist/nodes/Image.js
@@ -307,7 +307,7 @@ const ResizableWrapper = styled_components_1.default.div `
   }
 
   @media (max-width: 600px) {
-    max-width: 250px;
+    max-width: 330px;
   }
 
   ${({ width, height }) => width &&

--- a/src/nodes/Image.tsx
+++ b/src/nodes/Image.tsx
@@ -397,7 +397,7 @@ const ResizableWrapper = styled.div<{
   }
 
   @media (max-width: 600px) {
-    max-width: 330px;
+    max-width: 340px;
   }
 
   ${({ width, height }) =>

--- a/src/nodes/Image.tsx
+++ b/src/nodes/Image.tsx
@@ -397,7 +397,7 @@ const ResizableWrapper = styled.div<{
   }
 
   @media (max-width: 600px) {
-    max-width: 250px;
+    max-width: 330px;
   }
 
   ${({ width, height }) =>


### PR DESCRIPTION
since on this PR https://github.com/Knowt/KnowtWeb/pull/1426, our editor left and right are wider, now we can make the img size width wider as well.

```css
@media (max-width: 600px) {
    max-width: 340px;
}
```

`340px` seems enough considering tightest iphone screen is `375px`