### PR TITLE
fix line break search

### DIFF
--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -58,7 +58,8 @@ type State = {
   selectedIndex: number;
 };
 
-class CommandMenu<T = MenuItem> extends React.Component<Props<T>, State> {
+class CommandMenu<T extends MenuItem = MenuItem> 
+  extends React.Component<Props<T>, State> {
   menuRef = React.createRef<HTMLDivElement>();
   inputRef = React.createRef<HTMLInputElement>();
 

--- a/src/components/KnowtCommandMenu.tsx
+++ b/src/components/KnowtCommandMenu.tsx
@@ -751,10 +751,15 @@ class KnowtCommandMenu extends React.Component<Props, State> {
     const { dictionary, isActive, uploadImage } = this.props;
     const selectedGroup = this.filtered[this.state.selectedIndex];
 
+    let id = this.props.id || "block-menu-container";
+
+    if ( !isActive )
+      id += '-empty';
+
     return (
       <Portal>
         <Wrapper
-          id={this.props.id || "block-menu-container"}
+          id={id}
           active={isActive}
           ref={this.menuRef}
           style={{ maxHeight: this.state.menu1MaxHeight }}

--- a/src/components/KnowtCommandMenu.tsx
+++ b/src/components/KnowtCommandMenu.tsx
@@ -751,7 +751,7 @@ class KnowtCommandMenu extends React.Component<Props, State> {
     const { dictionary, isActive, uploadImage } = this.props;
     const selectedGroup = this.filtered[this.state.selectedIndex];
 
-    let id = this.props.id || "block-menu-container";
+    let id = "block-menu-container";
 
     if ( !isActive )
       id += '-empty';

--- a/src/components/KnowtCommandMenu.tsx
+++ b/src/components/KnowtCommandMenu.tsx
@@ -751,6 +751,8 @@ class KnowtCommandMenu extends React.Component<Props, State> {
     const { dictionary, isActive, uploadImage } = this.props;
     const selectedGroup = this.filtered[this.state.selectedIndex];
 
+    // this is necessary to escape search within the editor
+    // DO NOT change or assign custom id
     let id = "block-menu-container";
 
     if ( !isActive )

--- a/src/plugins/BlockMenuTrigger.tsx
+++ b/src/plugins/BlockMenuTrigger.tsx
@@ -90,10 +90,12 @@ export default class BlockMenuTrigger extends Extension {
               });
             }
 
+            const isSearchEmpty = document.getElementById( 'block-menu-container-empty' );
+
             // If the query is active and we're navigating the block menu then
             // just ignore the key events in the editor itself until we're done
             if (
-              event.key === "Enter" ||
+              ( event.key === "Enter" && !isSearchEmpty ) ||
               event.key === "ArrowUp" ||
               event.key === "ArrowDown" ||
               event.key === "Tab"


### PR DESCRIPTION
Fixes issue with searching for editor components

Now, the behavior is that when there are no component names that match the search criteria, we can now break to a new line.