### PR TITLE
toolbar changes

### DIFF
--- a/src/commands/defaultMarkClick.ts
+++ b/src/commands/defaultMarkClick.ts
@@ -1,0 +1,21 @@
+import { MenuItem } from "../types";
+
+interface Input {
+    item: MenuItem;
+    commands: Record<string, any>;
+}
+/**
+ * Handles default click on mark items in toolbar menu
+ */
+export const defaultMarkClick = (
+    input: Input,
+) => {
+    const { item, commands } = input;
+
+    if (item.customOnClick) {
+        return item.customOnClick();
+    }
+      
+    if (!item.name) return;
+    commands[item.name](item.attrs);
+}

--- a/src/commands/toggleMark.ts
+++ b/src/commands/toggleMark.ts
@@ -1,0 +1,42 @@
+import removeMarks from './removeMarks';
+import { defaultMarkClick } from './defaultMarkClick';
+import type { MenuItem } from '../types'
+import { EditorView } from 'prosemirror-view';
+import { MarkType } from "prosemirror-model";
+import { EditorState } from "prosemirror-state";
+
+
+interface Input {
+    item: MenuItem;
+    commands: Record<string, any>;
+    isMarkActive: (state: EditorState) => boolean;
+    view: EditorView;
+    allMarks: MarkType[];
+}
+/**
+ * Guarentees that a mark is toggled.
+ * Right now, it's used for background highlighting 
+ * because clicking an active highlight does not disable it
+ */
+export const toggleMark = (
+    input: Input,
+) => {
+    const { item, 
+        commands, 
+        isMarkActive,
+        view,
+        allMarks, } = input;
+
+    if ( !isMarkActive( view.state ) ) {
+        defaultMarkClick( {
+            item,
+            commands,
+        } );
+    }
+    else {
+        removeMarks(
+            view,
+            allMarks,
+        );
+    }
+}

--- a/src/components/SelectionToolbar.tsx
+++ b/src/components/SelectionToolbar.tsx
@@ -193,7 +193,7 @@ export default class SelectionToolbar extends React.Component<Props> {
     } else if (isDividerSelection) {
       items = getDividerMenuItems(state, dictionary);
     } else {
-      items = getFormattingMenuItems(view, isTemplate, dictionary);
+      items = getFormattingMenuItems(view, isTemplate, dictionary, this.props.commands);
       isTextSelection = true;
     }
 
@@ -204,8 +204,6 @@ export default class SelectionToolbar extends React.Component<Props> {
         return false;
       return true;
     });
-
-    // console.log(this.props.commands, items);
 
     items = filterExcessSeparators(items);
     if (!items.length) {

--- a/src/components/ToolbarMenu.tsx
+++ b/src/components/ToolbarMenu.tsx
@@ -5,6 +5,7 @@ import ToolbarButton from "./ToolbarButton";
 import ToolbarSeparator from "./ToolbarSeparator";
 import theme from "../styles/theme";
 import { MenuItem } from "../types";
+import { defaultMarkClick } from '../commands/defaultMarkClick';
 
 type Props = {
   tooltip: typeof React.Component | React.FC<any>;
@@ -40,14 +41,10 @@ class ToolbarMenu extends React.Component<Props> {
             <ToolbarButton
               key={index}
               active={isActive}
-              onClick={() => {
-                if (item.customOnClick) {
-                  return item.customOnClick();
-                }
-
-                if (!item.name) return;
-                this.props.commands[item.name](item.attrs);
-              }}
+              onClick={() => defaultMarkClick( {
+                item,
+                commands: this.props.commands,
+              })}
             >
               <Tooltip tooltip={item.tooltip} placement="top">
                 <Icon color={item.iconColor || this.props.theme.toolbarItem} />

--- a/src/menus/formatting.ts
+++ b/src/menus/formatting.ts
@@ -3,6 +3,7 @@ import {
   CodeIcon,
   Heading1Icon,
   Heading2Icon,
+  Heading3Icon,
   BlockQuoteIcon,
   LinkIcon,
   StrikethroughIcon,
@@ -14,19 +15,19 @@ import {
 } from "outline-icons";
 import { isInTable } from "@knowt/prosemirror-tables";
 import isInList from "../queries/isInList";
-import isMarkActive, { isAnyMarkActive } from "../queries/isMarkActive";
+import isMarkActive from "../queries/isMarkActive";
 import isNodeActive from "../queries/isNodeActive";
 import { MenuItem } from "../types";
 import baseDictionary from "../dictionary";
-import removeMarks from "../commands/removeMarks";
-import { RemoveIcon } from "../icons";
 import { EditorView } from "prosemirror-view";
 import _isSelectionEmpty from "../queries/isSelectionEmpty";
+import { toggleMark } from '../commands/toggleMark';
 
 export default function formattingMenuItems(
   view: EditorView,
   isTemplate: boolean,
-  dictionary: typeof baseDictionary
+  dictionary: typeof baseDictionary,
+  commands: Record<string, any>,
 ): MenuItem[] {
   const { state } = view;
   const { schema, selection } = state;
@@ -75,20 +76,19 @@ export default function formattingMenuItems(
       visible: allowBlocks && !isSelectionEmpty,
     },
     {
-      name: "highlight_default",
-      tooltip: "Red Highlight",
+      name: "highlight_blue",
+      tooltip: "Blue Highlight",
       icon: HighlightIcon,
-      iconColor: schema.marks.highlight_default.attrs.color.default,
-      active: isMarkActive(schema.marks.highlight_default),
+      iconColor: schema.marks.highlight_blue.attrs.color.default,
+      active: isMarkActive(schema.marks.highlight_blue),
       visible: !isTemplate && !isSelectionEmpty,
-    },
-    {
-      name: "highlight_orange",
-      tooltip: "Orange Highlight",
-      icon: HighlightIcon,
-      iconColor: schema.marks.highlight_orange.attrs.color.default,
-      active: isMarkActive(schema.marks.highlight_orange),
-      visible: !isTemplate && !isSelectionEmpty,
+      customOnClick: () => toggleMark( {
+        item: schema.marks.highlight_blue,
+        commands,
+        isMarkActive: isMarkActive(schema.marks.highlight_blue),
+        view,
+        allMarks,
+      } ),
     },
     {
       name: "highlight_yellow",
@@ -97,32 +97,68 @@ export default function formattingMenuItems(
       iconColor: schema.marks.highlight_yellow.attrs.color.default,
       active: isMarkActive(schema.marks.highlight_yellow),
       visible: !isTemplate && !isSelectionEmpty,
+      customOnClick: () => toggleMark( {
+        item: schema.marks.highlight_yellow,
+        commands,
+        isMarkActive: isMarkActive(schema.marks.highlight_yellow),
+        view,
+        allMarks,
+      } ),
     },
-    {
-      name: "highlight_green",
-      tooltip: "Green Highlight",
-      icon: HighlightIcon,
-      iconColor: schema.marks.highlight_green.attrs.color.default,
-      active: isMarkActive(schema.marks.highlight_green),
-      visible: !isTemplate && !isSelectionEmpty,
-    },
-    {
-      name: "highlight_blue",
-      tooltip: "Blue Highlight",
-      icon: HighlightIcon,
-      iconColor: schema.marks.highlight_blue.attrs.color.default,
-      active: isMarkActive(schema.marks.highlight_blue),
-      visible: !isTemplate && !isSelectionEmpty,
-    },
-    {
-      name: "highlight_remove",
-      tooltip: "Remove All Highlights",
-      icon: RemoveIcon,
-      iconColor: "#fff",
-      active: isAnyMarkActive(allMarks),
-      visible: !isTemplate && !isSelectionEmpty,
-      customOnClick: () => removeMarks(view, allMarks),
-    },
+    // {
+    //   name: "highlight_green",
+    //   tooltip: "Green Highlight",
+    //   icon: HighlightIcon,
+    //   iconColor: schema.marks.highlight_green.attrs.color.default,
+    //   active: isMarkActive(schema.marks.highlight_green),
+    //   visible: !isTemplate && !isSelectionEmpty,
+    //   customOnClick: () => toggleMark( {
+    //     item: schema.marks.highlight_green,
+    //     commands,
+    //     isMarkActive: isMarkActive(schema.marks.highlight_green),
+    //     view,
+    //     allMarks,
+    //   } ),
+    // },
+    // {
+    //   name: "highlight_remove",
+    //   tooltip: "Remove All Highlights",
+    //   icon: RemoveIcon,
+    //   iconColor: "#fff",
+    //   active: isAnyMarkActive(allMarks),
+    //   visible: !isTemplate && !isSelectionEmpty,
+    //   customOnClick: () => removeMarks(view, allMarks),
+    // },
+    // {
+    //   name: "highlight_default",
+    //   tooltip: "Red Highlight",
+    //   icon: HighlightIcon,
+    //   iconColor: schema.marks.highlight_default.attrs.color.default,
+    //   active: isMarkActive(schema.marks.highlight_default),
+    //   visible: !isTemplate && !isSelectionEmpty,
+    //   customOnClick: () => toggleMark( {
+    //     item: schema.marks.highlight_default,
+    //     commands,
+    //     isMarkActive: isMarkActive(schema.marks.highlight_default),
+    //     view,
+    //     allMarks,
+    //   } ),
+    // },
+    // {
+    //   name: "highlight_orange",
+    //   tooltip: "Orange Highlight",
+    //   icon: HighlightIcon,
+    //   iconColor: schema.marks.highlight_orange.attrs.color.default,
+    //   active: isMarkActive(schema.marks.highlight_orange),
+    //   visible: !isTemplate && !isSelectionEmpty,
+    //   customOnClick: () => toggleMark( {
+    //     item: schema.marks.highlight_orange,
+    //     commands,
+    //     isMarkActive: isMarkActive(schema.marks.highlight_orange),
+    //     view,
+    //     allMarks,
+    //   } ),
+    // },
     {
       name: "separator",
       visible: allowBlocks && !isSelectionEmpty,
@@ -151,6 +187,14 @@ export default function formattingMenuItems(
       icon: Heading2Icon,
       active: isNodeActive(schema.nodes.heading, { level: 2 }),
       attrs: { level: 2 },
+      visible: allowBlocks,
+    },
+    {
+      name: "heading",
+      tooltip: dictionary.subheading,
+      icon: Heading3Icon,
+      active: isNodeActive(schema.nodes.heading, { level: 3 }),
+      attrs: { level: 3 },
       visible: allowBlocks,
     },
     {


### PR DESCRIPTION
**simplifies toolbar - will continue to work on for future as more features are added**
- Add h3
- Only two colors (Blue and Yellow)
- Remove remove highlight icon since markers are togglable now
<img width="529" alt="Screen Shot 2022-10-07 at 3 05 40 PM" src="https://user-images.githubusercontent.com/68297416/194636069-f59a520d-7038-4d4c-8d7e-e142f5c6d1a3.png">

## Heading
<img width="422" alt="Screen Shot 2022-10-08 at 4 03 19 PM" src="https://user-images.githubusercontent.com/68297416/194725960-77c355d9-8732-484a-9867-911603b40a2e.png">

