### PR TITLE
Fix checklist toggle

### DIFF
--- a/src/commands/toggleList.ts
+++ b/src/commands/toggleList.ts
@@ -25,10 +25,20 @@ export default function toggleList(listType: NodeType, itemType: NodeType) {
       }
 
       if ( isList(parentList.node, schema) ) {
+        if ( listType.validContent(parentList.node.content) ) {
+          const { tr } = state;
+          tr.setNodeMarkup(parentList.pos, listType);
+
+          if (dispatch) {
+            dispatch(tr);
+          }
+  
+          return false;
+        }
         // Handles conversion between checklists and other lists.
         // TODO - conversions between checklists resets selection
         // stop that from happening!
-        if ( !listType.validContent(parentList.node.content) ) {
+        else {
           try {
             // @ts-ignore
             const content = parentList.node.content?.content as Node[];
@@ -64,16 +74,6 @@ export default function toggleList(listType: NodeType, itemType: NodeType) {
           catch ( error ) {
             console.warn( error?.message );
           }
-        }
-        else {
-          const { tr } = state;
-          tr.setNodeMarkup(parentList.pos, listType);
-
-          if (dispatch) {
-            dispatch(tr);
-          }
-  
-          return false;
         }
       }
     }

--- a/src/commands/toggleList.ts
+++ b/src/commands/toggleList.ts
@@ -1,6 +1,6 @@
 import { EditorState, Transaction } from "prosemirror-state";
 import { wrapInList, liftListItem } from "prosemirror-schema-list";
-import { findParentNode, setTextSelection } from "@knowt/prosemirror-utils";
+import { findParentNode } from "@knowt/prosemirror-utils";
 import isList from "../queries/isList";
 import { replaceParentNodeOfType } from '@knowt/prosemirror-utils';
 import type { NodeType, Fragment, Node } from "prosemirror-model";
@@ -74,9 +74,7 @@ export default function toggleList(listType: NodeType, itemType: NodeType) {
 
           if ( dispatch ) {
             dispatch(
-              setTextSelection( parentList.pos )(
-                replaceParentNodeOfType(parentList.node.type, newList)(state.tr)
-              )
+              replaceParentNodeOfType(parentList.node.type, newList)(state.tr)
             );
           }
 

--- a/src/commands/toggleList.ts
+++ b/src/commands/toggleList.ts
@@ -48,11 +48,14 @@ export default function toggleList(listType: NodeType, itemType: NodeType) {
                 isList( newContent.content[index].content.content[1], state.schema )
               ) {
                 // @ts-ignore
-                newContent.content[index].content.content[1] = convertListItemContent(
-                  // @ts-ignore
-                  newContent.content[index].content.content[1].content.content,
-                  // @ts-ignore
-                  newContent.content[index].content.content[1].content,
+                newContent.content[index].content = newContent.content[index].content.replaceChild(
+                  1,
+                  convertListItemContent(
+                    // @ts-ignore
+                    newContent.content[index].content.content[1].content.content,
+                    // @ts-ignore
+                    newContent.content[index].content.content[1].content,
+                  )
                 );
               }
             } );

--- a/src/commands/toggleList.ts
+++ b/src/commands/toggleList.ts
@@ -1,8 +1,9 @@
-import { NodeType } from "prosemirror-model";
 import { EditorState, Transaction } from "prosemirror-state";
 import { wrapInList, liftListItem } from "prosemirror-schema-list";
 import { findParentNode } from "@knowt/prosemirror-utils";
 import isList from "../queries/isList";
+import { replaceParentNodeOfType } from '@knowt/prosemirror-utils';
+import type { NodeType, Fragment, Node } from "prosemirror-model";
 
 export default function toggleList(listType: NodeType, itemType: NodeType) {
   return (state: EditorState, dispatch: (tr: Transaction) => void) => {
@@ -23,18 +24,55 @@ export default function toggleList(listType: NodeType, itemType: NodeType) {
         return liftListItem(itemType)(state, dispatch);
       }
 
-      if (
-        isList(parentList.node, schema) &&
-        listType.validContent(parentList.node.content)
-      ) {
-        const { tr } = state;
-        tr.setNodeMarkup(parentList.pos, listType);
+      if ( isList(parentList.node, schema) ) {
+        // handles conversion between checklists and other lists
+        if ( !listType.validContent(parentList.node.content) ) {
+          try {
+            // @ts-ignore
+            const content = parentList.node.content?.content as Node[];
+            let newContent: Fragment | undefined = undefined;
 
-        if (dispatch) {
-          dispatch(tr);
+            content.forEach( ( node, index ) => {
+              const contentToUse = newContent || parentList.node.content;
+              const newItem = itemType.create( 
+                undefined,
+                node.content,
+              );
+  
+              newContent = contentToUse.replaceChild(index, newItem);
+            } );
+
+            const newList = listType.create( 
+              undefined,
+              newContent,
+            );
+
+            if ( !newContent ) {
+              throw( new Error( `Could not convert list from ${parentList.node.type.name} to ${listType.name}`) );
+            }
+
+            if ( dispatch ) {
+              dispatch(
+                replaceParentNodeOfType(parentList.node.type, newList)(state.tr)
+              );
+            }
+  
+            return false;
+          }
+          catch ( error ) {
+            console.warn( error?.message );
+          }
         }
+        else {
+          const { tr } = state;
+          tr.setNodeMarkup(parentList.pos, listType);
 
-        return false;
+          if (dispatch) {
+            dispatch(tr);
+          }
+  
+          return false;
+        }
       }
     }
 

--- a/src/commands/toggleList.ts
+++ b/src/commands/toggleList.ts
@@ -25,7 +25,9 @@ export default function toggleList(listType: NodeType, itemType: NodeType) {
       }
 
       if ( isList(parentList.node, schema) ) {
-        // handles conversion between checklists and other lists
+        // Handles conversion between checklists and other lists.
+        // TODO - conversions between checklists resets selection
+        // stop that from happening!
         if ( !listType.validContent(parentList.node.content) ) {
           try {
             // @ts-ignore


### PR DESCRIPTION
THERE ARE STILL PROBLEMS WITH THIS IMPLEMENTATION, BUT I THINK IT WORKS WELL ENOUGH TO GO TO PROD

**What the code does:**
Previously, conversion between checklists and other lists was not possible. This resulted in clicking on the checklist button in the toolbar to try and convert, say a bullet list, would do nothing. Now it converts!

**Still need to work on:**
- Conversion between a checklist to other lists resets text selection, unlike conversion between bullet and ordered list.
- Nested list conversions are buggy. But this was the same for list conversion before too.

EDIT:
Nested list conversions works, but its messing up undo

EDIT EDIT:
EVERYTHING GOOD NOW!